### PR TITLE
[Add] 좋아요 생성/삭제, 좋아요 리스트 조회

### DIFF
--- a/db/migrations/20230206085159_alter_likes_table.sql
+++ b/db/migrations/20230206085159_alter_likes_table.sql
@@ -1,0 +1,5 @@
+-- migrate:up
+ALTER TABLE likes ADD created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP;
+
+-- migrate:down
+DROP TABLE likes;

--- a/src/controllers/like.controller.js
+++ b/src/controllers/like.controller.js
@@ -1,0 +1,31 @@
+const likeService = require('../services/like.service');
+const { catchAsync } = require('../utils/error');
+
+const createOrDeleteLike = catchAsync(async (req, res, next) => {
+  const { postId } = req.body;
+  const userId = req.user.id;
+
+  if (!postId) {
+    const err = new Error('KEY_ERROR');
+    err.statusCode = 400;
+    throw err;
+  }
+
+  const data = await likeService.createOrDeleteLike(userId, postId);
+
+  if (data) {
+    res.status(201).json({ message: 'likeCreated' });
+  } else {
+    res.status(204).end();
+  }
+});
+
+const getLikeList = catchAsync(async (req, res, next) => {
+  const userId = req.user.id;
+
+  const data = await likeService.getLikeList(userId);
+
+  res.status(200).json(data);
+});
+
+module.exports = { createOrDeleteLike, getLikeList };

--- a/src/models/like.dao.js
+++ b/src/models/like.dao.js
@@ -1,0 +1,54 @@
+const { appDataSource } = require('./dataSource');
+
+const isExistLike = async (userId, postId) => {
+  const [isExist] = await appDataSource.query(
+    `SELECT EXISTS(
+        SELECT *
+            FROM likes
+            WHERE user_id = ? and post_id = ? 
+    ) AS isExist;
+    `,
+    [userId, postId]
+  );
+  return isExist;
+};
+
+const createLike = async (userId, postId) => {
+  await appDataSource.query(
+    `INSERT INTO likes(
+        user_id, 
+        post_id
+    ) VALUES ( ?, ? );
+    `,
+    [userId, postId]
+  );
+};
+
+const deleteLike = async (userId, postId) => {
+  await appDataSource.query(
+    `DELETE 
+    FROM likes
+    WHERE user_id = ? and post_id = ?; 
+    `,
+    [userId, postId]
+  );
+};
+
+const getLikeList = async (userId) => {
+  return await appDataSource.query(
+    `SELECT 
+        p.id AS postId,
+        u.username AS authorName,
+        p.title,
+        l.created_at
+    FROM likes l
+    INNER JOIN posts p ON p.id = l.post_id
+    INNER JOIN users u ON u.id = p.user_id
+    WHERE l.user_id = ?
+    ORDER BY l.created_at DESC;
+    `,
+    [userId]
+  );
+};
+
+module.exports = { isExistLike, createLike, deleteLike, getLikeList };

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -2,8 +2,10 @@ const routes = require('express').Router();
 
 const { userRouter } = require('./user.router');
 const { postRouter } = require('./post.router');
+const { likeRouter } = require('./like.router');
 
 routes.use('/users', userRouter);
 routes.use('/posts', postRouter);
+routes.use('/likes', likeRouter);
 
 module.exports = { routes };

--- a/src/routes/like.router.js
+++ b/src/routes/like.router.js
@@ -1,0 +1,8 @@
+const likeRouter = require('express').Router();
+const likeController = require('../controllers/like.controller');
+const { checkAuth } = require('../utils/checkAuth');
+
+likeRouter.post('', checkAuth, likeController.createOrDeleteLike);
+likeRouter.get('/my', checkAuth, likeController.getLikeList);
+
+module.exports = { likeRouter };

--- a/src/services/like.service.js
+++ b/src/services/like.service.js
@@ -1,0 +1,22 @@
+const likeDao = require('../models/like.dao');
+
+const createOrDeleteLike = async (userId, postId) => {
+  const data = await likeDao.isExistLike(userId, postId);
+
+  if (data.isExist === '1') {
+    await likeDao.deleteLike(userId, postId);
+
+    return 0;
+  } else {
+    await likeDao.createLike(userId, postId);
+
+    return 1;
+  }
+};
+
+const getLikeList = async (userId) => {
+  const data = await likeDao.getLikeList(userId);
+  return data;
+};
+
+module.exports = { createOrDeleteLike, getLikeList };


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- 좋아요 생성/삭제, 좋아요 리스트 조회 API
<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. 좋아요 생성/삭제
- 좋아요 생성/삭제 API는 post HTTP메소드를 사용해 하나의 API로 구현

2. 좋아요 리스트 조회
- accessToken으로 불러온 userId를 기준으로 로그인 사용자가 좋아요를 누른 게시글의 
postId(게시글id), author(게시글 작성자), title(게시글 제목), created_at(생성 시간) 을 조회한다
- 리스트를 최신생성시간순으로 정렬하기 위해 테이블에 created_at 컬럼을 추가

<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)
- 좋아요 리스트 조회 시 조금 깊게 들어가면 정렬(sort) 서비스 로직을 구현해서 시간/작가/타이틀 가나다 순 할 수도 있을  거 같다.
- 
<br />

## :: 기타 질문 및 특이 사항
