### PR TITLE
[Add] 댓글 생성, 모아보기, 삭제 API

### DIFF
--- a/src/controllers/comment.controller.js
+++ b/src/controllers/comment.controller.js
@@ -1,0 +1,33 @@
+const commentService = require('../services/comment.service');
+const { catchAsync } = require('../utils/error');
+
+const createComment = catchAsync(async (req, res, next) => {
+  const { postId, content } = req.body;
+  const userId = req.user.id;
+
+  if (!postId) {
+    const err = new Error('KEY_ERROR');
+    err.statusCode = 400;
+    throw err;
+  }
+
+  await commentService.createComment(userId, postId, content);
+
+  res.status(201).json({ message: 'commentCreated' });
+});
+
+const getMyComment = catchAsync(async (req, res, next) => {
+  const userId = req.user.id;
+  const data = await commentService.getMyComment(userId);
+  res.status(200).json(data);
+});
+
+const deleteComment = catchAsync(async (req, res, next) => {
+  const userId = req.user.id;
+  const { commentId } = req.params;
+  await commentService.deleteComment(userId, commentId);
+
+  res.status(204).end();
+});
+
+module.exports = { createComment, getMyComment, deleteComment };

--- a/src/models/comment.dao.js
+++ b/src/models/comment.dao.js
@@ -1,0 +1,67 @@
+const { appDataSource } = require('./dataSource');
+
+const isCommentMine = async (userId, commentId) => {
+  const [isExist] = await appDataSource.query(
+    `SELECT EXISTS(
+        SELECT *
+            FROM comments
+            WHERE user_id = ? and id = ? 
+    ) AS isExist;
+    `,
+    [userId, commentId]
+  );
+  return isExist;
+};
+
+const createComment = async (userId, postId, content) => {
+  await appDataSource.query(
+    `INSERT INTO comments(
+        user_id, 
+        post_id,
+        content
+    ) VALUES ( ?, ?, ? );
+    `,
+    [userId, postId, content]
+  );
+};
+
+const getMyComment = async (userId) => {
+  const [data] = await appDataSource.query(
+    `SELECT 
+        c.user_id AS commenterId,
+        JSON_ARRAYAGG(
+            JSON_OBJECT(
+                "commentId", c.id,
+                "postId", c.post_id,
+                "postTitle", p.title,
+                "commentCreatedTime", c.created_at,
+                "commentUpdatedTime", c.updated_at,
+                "content", c.content
+            )
+        ) AS comment
+        FROM comments c
+        INNER JOIN posts p ON p.id = c.post_id
+        WHERE c.user_id = ? 
+        GROUP BY c.user_id;
+    `,
+    [userId]
+  );
+  return data;
+};
+
+const deleteComment = async (commentId) => {
+  await appDataSource.query(
+    `DELETE 
+    FROM comments
+    WHERE id = ?; 
+    `,
+    [commentId]
+  );
+};
+
+module.exports = {
+  isCommentMine,
+  createComment,
+  getMyComment,
+  deleteComment,
+};

--- a/src/routes/comment.router.js
+++ b/src/routes/comment.router.js
@@ -1,0 +1,9 @@
+const commentRouter = require('express').Router();
+const commentController = require('../controllers/comment.controller');
+const { checkAuth } = require('../utils/checkAuth');
+
+commentRouter.post('', checkAuth, commentController.createComment);
+commentRouter.get('', checkAuth, commentController.getMyComment);
+commentRouter.delete('/:commentId', checkAuth, commentController.deleteComment);
+
+module.exports = { commentRouter };

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -3,9 +3,11 @@ const routes = require('express').Router();
 const { userRouter } = require('./user.router');
 const { postRouter } = require('./post.router');
 const { likeRouter } = require('./like.router');
+const { commentRouter } = require('./comment.router');
 
 routes.use('/users', userRouter);
 routes.use('/posts', postRouter);
 routes.use('/likes', likeRouter);
+routes.use('/comments', commentRouter);
 
 module.exports = { routes };

--- a/src/services/comment.service.js
+++ b/src/services/comment.service.js
@@ -1,0 +1,23 @@
+const commentDao = require('../models/comment.dao');
+
+const createComment = async (userId, postId, content) => {
+  await commentDao.createComment(userId, postId, content);
+};
+
+const getMyComment = async (userId) => {
+  return await commentDao.getMyComment(userId);
+};
+
+const deleteComment = async (userId, commentId) => {
+  const data = await commentDao.isCommentMine(userId, commentId);
+
+  if (!data) {
+    const err = new Error(`Forbidden`);
+    err.statusCode = 403;
+    throw err;
+  }
+
+  await commentDao.deleteComment(commentId);
+};
+
+module.exports = { createComment, getMyComment, deleteComment };


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- 댓글 생성 API
- 내 댓글 모아보기 API
- 댓글 삭제 API
<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. 댓글 생성 API
- POST http 메소드를 사용해 req.body에 postId, content를 받아 댓글 생성하고 적절한 상태코드(201)와 메시지 반환
- 
2. 내 댓글 모아보기 API
- (특정 게시글의 댓글 조회 기능은 특정 게시글 조회에 포함되어 있으므로 이 기능과는 다름)
- 네이버웹툰의 내 댓글 모아보기 기능을 모델링한 기능으로 accessToken에서 불러온 userId를 기준으로 각 포스트 당 작성된 댓글 모아보기 목적으로 함.  
- 
3. 댓글 삭제 API
- accessToken으로 불러온 userId를 기준으로 댓글을 삭제할 수 있다
- userId와 commentId를 기준으로 해당 댓글이 본인 댓글일 경우에만 삭제할 수 있고 아닐 경우 403 권한없음 에러를 반환한다

<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)

<br />

## :: 기타 질문 및 특이 사항
